### PR TITLE
Fixed failing to start without Ollama

### DIFF
--- a/src/llm/ollama_client.py
+++ b/src/llm/ollama_client.py
@@ -1,14 +1,25 @@
+import httpx
 import ollama
+
+from src.logger import Logger
+
 
 class Ollama:
     @staticmethod
     def list_models():
-        return ollama.list()["models"]
+        try:
+            return ollama.list()["models"]
+        except httpx.ConnectError:
+            Logger().warning("Ollama server not running, please start the server to use models from Ollama.")
+        except Exception as e:
+            Logger().error(f"Failed to list Ollama models: {e}")
+
+        return []
 
     def inference(self, model_id: str, prompt: str) -> str:
         response = ollama.generate(
             model = model_id,
             prompt = prompt.strip()
         )
-        
+
         return response['response']


### PR DESCRIPTION
This pull request includes changes to the `src/llm/ollama_client.py` file to improve error handling and logging. The `list_models` method in the `Ollama` class has been modified to catch exceptions when attempting to list models from the Ollama server, and to log relevant warnings or errors. If an exception occurs, an empty list is returned.

* [`src/llm/ollama_client.py`](diffhunk://#diff-a4dd1a947807d1a3a36b0bc5c33ce7913cbfe8f28adddd8af82b33602b0231d4R1-R17): Added error handling and logging to the `list_models` method in the `Ollama` class. If the Ollama server is not running, a warning is logged and an empty list is returned. If any other exception occurs, an error is logged with the exception details and an empty list is returned.

## Closes

Handle ollama server not running bug #9