### PR TITLE
chore: update README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,29 +66,34 @@ Devika's system architecture consists of the following key components:
 Read [**ARCHITECTURE.md**](https://github.com/stitionai/devika/blob/main/ARCHITECTURE.md) for the detailed documentation.
 
 ## Installation
+Devika requires the following things as dependencies:
+- Ollama (follow the instructions here to install it: [https://ollama.com/](https://ollama.com/))
+- Bun (follow the instructions here to install it: [https://bun.sh/](https://ollama.com/))
 
 To install Devika, follow these steps:
 
 1. Clone the Devika repository:
-   ```
+   ```bash
    git clone https://github.com/stitionai/devika.git
    ```
 2. Navigate to the project directory:
-   ```
+   ```bash
    cd devika
    ```
 3. Install the required dependencies:
-   ```
+   ```bash
    pip install -r requirements.txt
+   playwright install --with-deps # installs browsers in playwright (and their deps) if required
    ```
 4. Set up the necessary API keys and configuration (see [Configuration](#configuration) section).
 5. Start the Devika server:
-   ```
+   ```bash
    python devika.py
    ```
 6. Compile and run the UI server:
-   ```
+   ```bash
    cd ui/
+   bun install
    bun run dev
    ```
 7. Access the Devika web interface by opening a browser and navigating to `http://127.0.0.1:3000`.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Read [**ARCHITECTURE.md**](https://github.com/stitionai/devika/blob/main/ARCHITE
 ## Installation
 Devika requires the following things as dependencies:
 - Ollama (follow the instructions here to install it: [https://ollama.com/](https://ollama.com/))
-- Bun (follow the instructions here to install it: [https://bun.sh/](https://ollama.com/))
+- Bun (follow the instructions here to install it: [https://bun.sh/](https://bun.sh/))
 
 To install Devika, follow these steps:
 


### PR DESCRIPTION
The README instructions are a vague about certain dependencies (like Ollama, Bun and Playwright dependencies) and doesn't go through it well. This PR intends to add helpful info into the installation process.

## What's changed
- Added mention of Ollama and Bun as dependencies.
- Added section to instruct users to install Playwright Browsers and their dependencies
- Added a step to let users install dependencies using bun.