### PR TITLE
fix: openai models crashing

### DIFF
--- a/src/llm/llm.py
+++ b/src/llm/llm.py
@@ -4,8 +4,6 @@ from .ollama_client import Ollama
 from .claude_client import Claude
 from .openai_client import OpenAI
 
-from src.state import AgentState
-
 import tiktoken
 
 TOKEN_USAGE = 0

--- a/src/llm/openai_client.py
+++ b/src/llm/openai_client.py
@@ -1,12 +1,12 @@
-from openai import OpenAI
+from openai import OpenAI as OAI
 
 from src.config import Config
 
 class OpenAI:
-    def __init__(self, api_key: str):
+    def __init__(self):
         config = Config()
         api_key = config.get_openai_api_key()
-        self.client = OpenAI(
+        self.client = OAI(
             api_key=api_key,
         )
         


### PR DESCRIPTION
This PR intends to fix OpenAI Models (GPT-x models) crashing out the system or run into weird issues when using them.

## What's changed
This is pretty much a two line change that removes the unused `api_key` constructor positional argument in the OpenAI client class. Along with that, there is an ambiguity in the constructor of the OpenAI class where Python thinks its a recursive class creation rather than the actually meant usage of the OpenAI module class.

```python
from openai import OpenAI # <- What we ideally meant

class OpenAI: # <- What Python thinks the ambiguity resolves into.
    def __init__(self, api_key: str):
        config = Config()
        api_key = config.get_openai_api_key()
        self.client = OpenAI( # <- The ambiguity
            api_key=api_key,
        )
```

The solution is to introduce an alias to the import so Python can understand what was meant.

The OpenAI agents in my experience have more problems as well (token usage not being updated and stuff). Will look into that hopefully as well.