### PR TITLE
Fixed SSR issues

### DIFF
--- a/ui/src/lib/components/ControlPanel.svelte
+++ b/ui/src/lib/components/ControlPanel.svelte
@@ -3,8 +3,8 @@
   import { projectList, modelList, internet } from "$lib/store";
   import { createProject, fetchProjectList, getTokenUsage } from "$lib/api";
 
-  let selectedProject = localStorage.getItem("selectedProject") || "Select Project";
-  let selectedModel = localStorage.getItem("selectedModel") || "Select Model";
+  let selectedProject;
+  let selectedModel;
   let tokenUsage = 0;
 
   async function updateTokenUsage() {
@@ -53,6 +53,9 @@
 
   onMount(() => {
     setInterval(updateTokenUsage, 1000);
+
+    selectedProject = localStorage.getItem("selectedProject") || "Select Project";
+    selectedModel = localStorage.getItem("selectedModel") || "Select Model";
 
     document
       .getElementById("project-button")

--- a/ui/src/lib/components/TerminalWidget.svelte
+++ b/ui/src/lib/components/TerminalWidget.svelte
@@ -1,22 +1,24 @@
 <script>
   import { onMount } from "svelte";
-  import { Terminal } from "xterm";
   import "xterm/css/xterm.css";
-  import { FitAddon } from "xterm-addon-fit";
   import { agentState } from "$lib/store";
 
   let terminalElement;
   let terminal;
   let fitAddon;
 
-  onMount(() => {
-    terminal = new Terminal({
+  onMount(async () => {
+    let xterm = await import('xterm');
+    let xtermAddonFit = await('xterm-addon-fit')
+
+    terminal = new xterm.Terminal({
       disableStdin: true,
       cursorBlink: true,
       convertEol: true,
       rows: 1,
     });
-    fitAddon = new FitAddon();
+    
+    fitAddon = new xtermAddonFit.FitAddon();
     terminal.loadAddon(fitAddon);
     terminal.open(terminalElement);
     fitAddon.fit();

--- a/ui/src/routes/+layout.js
+++ b/ui/src/routes/+layout.js
@@ -1,1 +1,0 @@
-export const ssr = false


### PR DESCRIPTION
This PR aims to re-enable SSR which was disabled earlier.

## Changes

1. Removed `export const ssr = false` in `ui/src/routes/+layout.js`
2. `TerminalWidget.svelte`: Moved `xterm` and `xterm-addon-fit` imports into `onMount()`
3. `ControlPanel.svelte`: Moved localStorage variable stuff into `onMount()`