### PR TITLE
Add OLLAMA Endpoint to config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,3 +14,4 @@ OPENAI = "<YOUR_OPENAI_API_KEY>"
 
 [API_ENDPOINTS]
 BING = "https://api.bing.microsoft.com/v7.0/search"
+OLLAMA = "http://127.0.0.1:11434"

--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,6 @@
 import toml
 
+
 class Config:
     def __init__(self):
         self.config = toml.load("config.toml")
@@ -9,37 +10,40 @@ class Config:
 
     def get_bing_api_key(self):
         return self.config["API_KEYS"]["BING"]
-    
+
     def get_bing_api_endpoint(self):
         return self.config["API_ENDPOINTS"]["BING"]
-    
+
+    def get_ollama_api_endpoint(self):
+        return self.config["API_ENDPOINTS"]["OLLAMA"]
+
     def get_claude_api_key(self):
         return self.config["API_KEYS"]["CLAUDE"]
-    
+
     def get_openai_api_key(self):
         return self.config["API_KEYS"]["OPENAI"]
-    
+
     def get_netlify_api_key(self):
         return self.config["API_KEYS"]["NETLIFY"]
-    
+
     def get_sqlite_db(self):
         return self.config["STORAGE"]["SQLITE_DB"]
-    
+
     def get_screenshots_dir(self):
         return self.config["STORAGE"]["SCREENSHOTS_DIR"]
-    
+
     def get_pdfs_dir(self):
         return self.config["STORAGE"]["PDFS_DIR"]
-    
+
     def get_projects_dir(self):
         return self.config["STORAGE"]["PROJECTS_DIR"]
-    
+
     def get_logs_dir(self):
         return self.config["STORAGE"]["LOGS_DIR"]
-    
+
     def get_repos_dir(self):
         return self.config["STORAGE"]["REPOS_DIR"]
-    
+
     def set_bing_api_key(self, key):
         self.config["API_KEYS"]["BING"] = key
         self.save_config()
@@ -47,7 +51,11 @@ class Config:
     def set_bing_api_endpoint(self, endpoint):
         self.config["API_ENDPOINTS"]["BING"] = endpoint
         self.save_config()
-        
+
+    def set_ollama_api_endpoint(self, endpoint):
+        self.config["API_ENDPOINTS"]["OLLAMA"] = endpoint
+        self.save_config()
+
     def set_claude_api_key(self, key):
         self.config["API_KEYS"]["CLAUDE"] = key
         self.save_config()
@@ -59,11 +67,11 @@ class Config:
     def set_netlify_api_key(self, key):
         self.config["API_KEYS"]["NETLIFY"] = key
         self.save_config()
-        
+
     def set_sqlite_db(self, db):
         self.config["STORAGE"]["SQLITE_DB"] = db
         self.save_config()
-        
+
     def set_screenshots_dir(self, dir):
         self.config["STORAGE"]["SCREENSHOTS_DIR"] = dir
         self.save_config()
@@ -71,7 +79,7 @@ class Config:
     def set_pdfs_dir(self, dir):
         self.config["STORAGE"]["PDFS_DIR"] = dir
         self.save_config()
-        
+
     def set_projects_dir(self, dir):
         self.config["STORAGE"]["PROJECTS_DIR"] = dir
         self.save_config()

--- a/src/llm/ollama_client.py
+++ b/src/llm/ollama_client.py
@@ -1,25 +1,27 @@
 import httpx
-import ollama
+from ollama import Client
+from src.config import Config
 
 from src.logger import Logger
+
+client = Client(host=Config().get_ollama_api_endpoint())
 
 
 class Ollama:
     @staticmethod
     def list_models():
         try:
-            return ollama.list()["models"]
+            return client.list()["models"]
         except httpx.ConnectError:
-            Logger().warning("Ollama server not running, please start the server to use models from Ollama.")
+            Logger().warning(
+                "Ollama server not running, please start the server to use models from Ollama."
+            )
         except Exception as e:
             Logger().error(f"Failed to list Ollama models: {e}")
 
         return []
 
     def inference(self, model_id: str, prompt: str) -> str:
-        response = ollama.generate(
-            model = model_id,
-            prompt = prompt.strip()
-        )
+        response = client.generate(model=model_id, prompt=prompt.strip())
 
-        return response['response']
+        return response["response"]


### PR DESCRIPTION
Adding support for a configurable OLLAMA Endpoint, for two reasons:
- Hosting ollama on a rented GPU instance is a common use-case, and we'd want to make it easy for those users as well
- Especially as we add docker support, ollama is going to be the part that moves the most, it would be nice to have the _option_ to use another instance

Thanks!