### PR TITLE
fix: typing annotation

### DIFF
--- a/src/llm/llm.py
+++ b/src/llm/llm.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import List, Tuple
 
 from .ollama_client import Ollama
 from .claude_client import Claude
@@ -27,7 +28,7 @@ class LLM:
     def __init__(self, model_id: str = None):
         self.model_id = model_id
     
-    def list_models(self) -> list[tuple[str, str]]:
+    def list_models(self) -> List[Tuple[str, str]]:
         return [model.value for model in Model if model.name != "OLLAMA_MODELS"] + list(
             Model.OLLAMA_MODELS.value
         )


### PR DESCRIPTION
fix issue that using python class _list[tuple[str, str]]_ as typing annotation

Traceback (most recent call last):
  File "devika.py", line 16, in <module>
    from src.agents import Agent
  File "./devika/src/agents/__init__.py", line 1, in <module>
    from .agent import Agent
  File "./devika/src/agents/agent.py", line 1, in <module>
    from .planner import Planner
  File "./devika/src/agents/planner/__init__.py", line 1, in <module>
    from .planner import Planner
  File "./devika/src/agents/planner/planner.py", line 3, in <module>
    from src.llm import LLM
  File "./devika/src/llm/__init__.py", line 1, in <module>
    from .llm import LLM, TOKEN_USAGE
  File "./devika/src/llm/llm.py", line 26, in <module>
    class LLM:
  File "./devika/src/llm/llm.py", line 30, in LLM
    def list_models(self) -> list[tuple[str, str]]:
TypeError: 'type' object is not subscriptable