### PR TITLE
Fixed: unresponsive TerminalWidget and Anchortag error (minor changes)

### DIFF
--- a/ui/src/lib/components/ControlPanel.svelte
+++ b/ui/src/lib/components/ControlPanel.svelte
@@ -111,22 +111,20 @@
       tabindex="-1"
     >
       <div class="py-1" role="none">
-        <a
-          href="#"
+        <button
           class="text-white block px-4 py-2 text-sm hover:bg-slate-700"
           on:click|preventDefault={createNewProject}
         >
           + Create new project
-        </a>
+      </button>
         {#if $projectList !== null}
           {#each $projectList as project}
-            <a
-              href="#"
+            <button
               class="text-white block px-4 py-2 text-sm hover:bg-slate-700"
               on:click|preventDefault={() => selectProject(project)}
             >
               {project}
-            </a>
+            </button>
           {/each}
         {/if}
       </div>
@@ -182,13 +180,12 @@
         <div class="py-1" role="none">
           {#if $modelList !== null}
             {#each $modelList as model}
-              <a
-                href="#"
+              <button
                 class="text-white block px-4 py-2 text-sm hover:bg-slate-700"
                 on:click|preventDefault={() => selectModel(model)}
               >
                 {model[0]} ({model[1]})
-              </a>
+               </button>
             {/each}
           {/if}
         </div>

--- a/ui/src/lib/components/TerminalWidget.svelte
+++ b/ui/src/lib/components/TerminalWidget.svelte
@@ -8,17 +8,17 @@
   let fitAddon;
 
   onMount(async () => {
-    let xterm = await import('xterm');
-    let xtermAddonFit = await('xterm-addon-fit')
+    const { Terminal } = await import('xterm');
+    const { FitAddon } = await import('xterm-addon-fit');
 
-    terminal = new xterm.Terminal({
+    terminal = new Terminal({
       disableStdin: true,
       cursorBlink: true,
       convertEol: true,
       rows: 1,
     });
     
-    fitAddon = new xtermAddonFit.FitAddon();
+    fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);
     terminal.open(terminalElement);
     fitAddon.fit();


### PR DESCRIPTION
The Terminal in the UI was just staying blank and not showing any information, this was fixed in TerminalWidget.svelte.

Unused Anchor tags in ControlPanel.svelte produced an Error message:
"..ui/src/lib/components/ControlPanel.svelte:186:16 A11y: '#' is not a valid href attribute"
Changing the anchors to Buttons fixed this. 



