### PR TITLE
Fix - model_id

### DIFF
--- a/ui/src/lib/components/ControlPanel.svelte
+++ b/ui/src/lib/components/ControlPanel.svelte
@@ -14,7 +14,7 @@
   }
 
   function selectModel(model) {
-    $selectedModel = `${model[0]} (${model[1]})`;
+    $selectedModel = `${model[1]}`;
   }
 
   async function createNewProject() {


### PR DESCRIPTION
After recent UI  code merges, when model is selected, UI is returning whole (model name + model id) instead of model_id.

simple example : 
Before UI change : 
lets take  "GPT-4 Turbo" model is selected, UI will set model id as  "gpt-4-0125-preview". Useful for model_client obj creation.
After recent change:
UI will set model_id to GPT-4 Turbo (gpt-4-0125-preview), which will prevent model_client obj creation and further running of program.


It will cause issue for all model_client obj creation such as Groq, Ollama, OpenAI.

FIxed this issue, Now UI will return only model_id.

-> Tested thoroughly.

Thank you !

