### PR TITLE
Fix - Groq_client issues

### DIFF
--- a/src/llm/groq_client.py
+++ b/src/llm/groq_client.py
@@ -1,15 +1,16 @@
-from groq import Groq
+from groq import Groq as _Groq
 
 from src.config import Config
 
+
 class Groq:
-    def __init__(self, api_key: str):
+    def __init__(self):
         config = Config()
         api_key = config.get_groq_api_key()
-        self.client = Groq(
+        self.client = _Groq(
             api_key=api_key,
         )
-        
+
     def inference(self, model_id: str, prompt: str) -> str:
         chat_completion = self.client.chat.completions.create(
             messages=[


### PR DESCRIPTION
*************** Fixes  Groq client *********************

Issues :
-> groq package and the groq_client file had same class name.
-> __init__ method had api_key as argument and It was not an optional field and also while object creation api_key was not supplied, which prevented groq_client object creation.
-> Due to the above issues, groq_client was not working.

Fixes made:
->imported Groq class from the package as  _Groq (as it was used, only internally). which solves Groq object creation.
-> removed the api_key argument in __init__ method, as it was not need.

**Tested thoroughly** , now groq_client works smoothly as expected! 