### PR TITLE
Fix - recursive rendering

### DIFF
--- a/src/agents/decision/decision.py
+++ b/src/agents/decision/decision.py
@@ -33,8 +33,8 @@ class Decision:
         return response
 
     def execute(self, prompt: str, project_name: str) -> str:
-        prompt = self.render(prompt)
-        response = self.llm.inference(prompt, project_name)
+        rendered_prompt = self.render(prompt)
+        response = self.llm.inference(rendered_prompt, project_name)
         
         valid_response = self.validate_response(response)
         

--- a/src/agents/internal_monologue/internal_monologue.py
+++ b/src/agents/internal_monologue/internal_monologue.py
@@ -34,8 +34,8 @@ class InternalMonologue:
             return response["internal_monologue"]
 
     def execute(self, current_prompt: str, project_name: str) -> str:
-        current_prompt = self.render(current_prompt)
-        response = self.llm.inference(current_prompt, project_name)
+        rendered_prompt = self.render(current_prompt)
+        response = self.llm.inference(rendered_prompt, project_name)
         
         valid_response = self.validate_response(response)
         

--- a/src/agents/researcher/researcher.py
+++ b/src/agents/researcher/researcher.py
@@ -43,10 +43,10 @@ class Researcher:
             }
 
     def execute(self, step_by_step_plan: str, contextual_keywords: List[str], project_name: str) -> str:
-        contextual_keywords = ", ".join(map(lambda k: k.capitalize(), contextual_keywords))
-        step_by_step_plan = self.render(step_by_step_plan, contextual_keywords)
+        contextual_keywords_str = ", ".join(map(lambda k: k.capitalize(), contextual_keywords))
+        prompt = self.render(step_by_step_plan, contextual_keywords_str)
         
-        response = self.llm.inference(step_by_step_plan, project_name)
+        response = self.llm.inference(prompt, project_name)
         
         valid_response = self.validate_response(response)
 


### PR DESCRIPTION
### Issues
Some agents reuse the arguments to save the rendered prompt, but this may cause the prompt to be nested or with extra commas if the response isn't valid on the first try. 
### Changes
Renaming variables in these functions to avoid changing the original arguments.