### PR TITLE
Refactored config.py: Replaced 'config.toml' by _CONFIG_FILE

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -4,15 +4,16 @@ from os import environ
 
 class Config:
     _instance = None
+    _CONFIG_FILE = "config.toml"
 
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super().__new__(cls)
-            cls._instance.config = toml.load("config.toml")
+            cls._instance.config = toml.load(cls._CONFIG_FILE)
         return cls._instance
 
     def __init__(self):
-        self.config = toml.load("config.toml")
+        self.config = toml.load(self._CONFIG_FILE)
 
     def get_config(self):
         return self.config
@@ -121,5 +122,5 @@ class Config:
         self.save_config()
 
     def save_config(self):
-        with open("config.toml", "w") as f:
+        with open(self._CONFIG_FILE, "w") as f:
             toml.dump(self.config, f)


### PR DESCRIPTION
In the class `Config` in `config.py`, I replaced the multiple occurences of `'config.toml'` by the class constant `_CONFIG_FILE`.
This aims to make the code:
* easier to maintain
* clearer

by: 
* expliciting what "config.toml" represents
* reducing the amount of literal values in the code.

PS: 
This is my first contribution to an open source project.
I would highly value any comment that would help me make better contributions in the future