### PR TITLE
Add tests for the Config class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,5 +159,8 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+# Visual Studio Code project settings
+.vscode/
+
 notes.md
 data/

--- a/devika.py
+++ b/devika.py
@@ -183,7 +183,7 @@ def set_settings():
     data = request.json
     print("Data: ", data)
     config.config.update(data)
-    config.save_config()
+    config.dump_config()
     return jsonify({"message": "Settings updated"})
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -4,6 +4,7 @@ import os
 
 class Config:
     _instance = None
+    _CONFIG_FILE = "config.toml"
 
     def __new__(cls):
         if cls._instance is None:
@@ -13,11 +14,11 @@ class Config:
 
     def _load_config(self):
         # If the config file doesn't exist, copy from the sample
-        if not os.path.exists("config.toml"):
-            with open("sample.config.toml", "r") as f_in, open("config.toml", "w") as f_out:
+        if not os.path.exists(self._CONFIG_FILE):
+            with open("sample.config.toml", "r") as f_in, open(self._CONFIG_FILE, "w") as f_out:
                 f_out.write(f_in.read())
 
-        self.config = toml.load("config.toml")
+        self.config = toml.load(self._CONFIG_FILE)
 
     def get_config(self):
         return self.config
@@ -163,5 +164,5 @@ class Config:
         self.save_config()
 
     def save_config(self):
-        with open("config.toml", "w") as f:
+        with open(self._CONFIG_FILE, "w") as f:
             toml.dump(self.config, f)

--- a/src/config.py
+++ b/src/config.py
@@ -5,6 +5,7 @@ import os
 class Config:
     _instance = None
     _CONFIG_FILE = "config.toml"
+    _SAMPLE_CONFIG_FILE = "sample.config.toml"
 
     def __new__(cls):
         if cls._instance is None:
@@ -15,7 +16,7 @@ class Config:
     def _load_config(self):
         # If the config file doesn't exist, copy from the sample
         if not os.path.exists(self._CONFIG_FILE):
-            with open("sample.config.toml", "r") as f_in, open(self._CONFIG_FILE, "w") as f_out:
+            with open(self._SAMPLE_CONFIG_FILE, "r") as f_in, open(self._CONFIG_FILE, "w") as f_out:
                 f_out.write(f_in.read())
 
         self.config = toml.load(self._CONFIG_FILE)

--- a/src/config.py
+++ b/src/config.py
@@ -85,11 +85,11 @@ class Config:
 
     def set_bing_api_key(self, key):
         self.config["API_KEYS"]["BING"] = key
-        self.save_config()
+        self.dump_config()
 
     def set_bing_api_endpoint(self, endpoint):
         self.config["API_ENDPOINTS"]["BING"] = endpoint
-        self.save_config()
+        self.dump_config()
 
     def set_google_search_api_key(self, key):
         self.config["API_KEYS"]["GOOGLE_SEARCH"] = key
@@ -105,15 +105,15 @@ class Config:
 
     def set_ollama_api_endpoint(self, endpoint):
         self.config["API_ENDPOINTS"]["OLLAMA"] = endpoint
-        self.save_config()
+        self.dump_config()
 
     def set_claude_api_key(self, key):
         self.config["API_KEYS"]["CLAUDE"] = key
-        self.save_config()
+        self.dump_config()
 
     def set_openai_api_key(self, key):
         self.config["API_KEYS"]["OPENAI"] = key
-        self.save_config()
+        self.dump_config()
 
     def set_gemini_api_key(self, key):
         self.config["API_KEYS"]["GEMINI"] = key
@@ -129,40 +129,40 @@ class Config:
 
     def set_netlify_api_key(self, key):
         self.config["API_KEYS"]["NETLIFY"] = key
-        self.save_config()
+        self.dump_config()
 
     def set_sqlite_db(self, db):
         self.config["STORAGE"]["SQLITE_DB"] = db
-        self.save_config()
+        self.dump_config()
 
     def set_screenshots_dir(self, dir):
         self.config["STORAGE"]["SCREENSHOTS_DIR"] = dir
-        self.save_config()
+        self.dump_config()
 
     def set_pdfs_dir(self, dir):
         self.config["STORAGE"]["PDFS_DIR"] = dir
-        self.save_config()
+        self.dump_config()
 
     def set_projects_dir(self, dir):
         self.config["STORAGE"]["PROJECTS_DIR"] = dir
-        self.save_config()
+        self.dump_config()
 
     def set_logs_dir(self, dir):
         self.config["STORAGE"]["LOGS_DIR"] = dir
-        self.save_config()
+        self.dump_config()
 
     def set_repos_dir(self, dir):
         self.config["STORAGE"]["REPOS_DIR"] = dir
-        self.save_config()
+        self.dump_config()
 
     def set_logging_rest_api(self, value):
         self.config["LOGGING"]["LOG_REST_API"] = "true" if value else "false"
-        self.save_config()
+        self.dump_config()
 
     def set_logging_prompts(self, value):
         self.config["LOGGING"]["LOG_PROMPTS"] = "true" if value else "false"
-        self.save_config()
+        self.dump_config()
 
-    def save_config(self):
+    def dump_config(self):
         with open(self._CONFIG_FILE, "w") as f:
             toml.dump(self.config, f)

--- a/src/config.py
+++ b/src/config.py
@@ -94,15 +94,15 @@ class Config:
 
     def set_google_search_api_key(self, key):
         self.config["API_KEYS"]["GOOGLE_SEARCH"] = key
-        self.save_config()
+        self.dump_config()
 
     def set_google_search_engine_id(self, key):
         self.config["API_KEYS"]["GOOGLE_SEARCH_ENGINE_ID"] = key
-        self.save_config()
+        self.dump_config()
 
     def set_google_search_api_endpoint(self, endpoint):
         self.config["API_ENDPOINTS"]["GOOGLE_SEARCH"] = endpoint
-        self.save_config()
+        self.dump_config()
 
     def set_ollama_api_endpoint(self, endpoint):
         self.config["API_ENDPOINTS"]["OLLAMA"] = endpoint
@@ -118,15 +118,15 @@ class Config:
 
     def set_gemini_api_key(self, key):
         self.config["API_KEYS"]["GEMINI"] = key
-        self.save_config()
+        self.dump_config()
 
     def set_mistral_api_key(self, key):
         self.config["API_KEYS"]["MISTRAL"] = key
-        self.save_config()
+        self.dump_config()
 
     def set_groq_api_key(self, key):
         self.config["API_KEYS"]["GROQ"] = key
-        self.save_config()
+        self.dump_config()
 
     def set_netlify_api_key(self, key):
         self.config["API_KEYS"]["NETLIFY"] = key

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,12 +26,12 @@ class TestConfig:
         return mocker.patch("src.config.Config._CONFIG_FILE", p)
 
     @fixture
-    def patch_toml_load(self, mocker):
+    def patch_load_config(self, mocker):
         """
-        Patch every use of toml.load in class Config
-        The return value from toml.load is changed to `{}`
+        Patch load_config in class Config
+        The return value from load_config is changed to `{}`
         """
-        return mocker.patch("src.config.toml.load", return_value={})
+        return mocker.patch("src.config.Config.load_config", return_value={})
 
     def test_creation(self, setup, patch_config):
         assert Config() is not None
@@ -39,9 +39,9 @@ class TestConfig:
     def test_singleton(self, setup, patch_config):
         assert Config() == Config()
 
-    def test_toml_load_called_once_during_multiple_access(self, setup, patch_config, patch_toml_load):
+    def test_load_config_called_once_during_multiple_access(self, setup, patch_config, patch_load_config):
         Config(), Config(), Config(), Config(), Config()
-        patch_toml_load.assert_called_once()
+        patch_load_config.assert_called_once()
 
     def test_save_config_correctly_saves_config(self, setup, patch_config):
         # Read config from file and modify values

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,56 @@
+from src.config import Config
+import os
+import shutil
+from pytest import fixture
+
+
+class TestConfig:
+
+    _TEST_CONFIG_FILE = "sample.config.toml"
+
+    @fixture
+    def patch_config(self, mocker, tmpdir):
+        """
+        Patch the class Config
+        Config._CONFIG_FILE is changed to point to the example config file
+        """
+        assert os.path.isfile(self._TEST_CONFIG_FILE)
+        p = tmpdir
+        p = shutil.copy(self._TEST_CONFIG_FILE, p)
+        return mocker.patch("src.config.Config._CONFIG_FILE", p)
+
+    @fixture
+    def patch_toml_load(self, mocker):
+        """
+        Patch every use of toml.load in class Config
+        The return value from toml.load is changed to `{}`
+        """
+        return mocker.patch("src.config.toml.load", return_value={})
+
+    def test_creation(self, patch_config):
+        assert Config() is not None
+    
+    def test_singleton(self, patch_config):
+        assert Config() == Config()
+
+    def test_toml_load_called_once_during_multiple_access(self, patch_toml_load):
+        Config(), Config(), Config(), Config(), Config()
+        patch_toml_load.assert_called_once()
+
+    def test_save_config_correctly_saves_config(self, patch_config):
+        # Read config from file and modify values
+        Config().set_bing_api_key("10random_bing_key01")
+        Config().set_logs_dir("10random_logs_dir01")
+        # (as of March 28th, setters save to file)
+        # Get the config that was written to file 
+        config_saved = Config().get_config()
+        # Force loading of the config from the file by deleting singleton
+        Config()._instance = None
+        # Get the config loaded from file
+        config_loaded = Config().get_config()
+
+        assert config_saved == config_loaded
+        
+
+
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,7 +56,3 @@ class TestConfig:
         config_loaded = Config().get_config()
 
         assert config_saved == config_loaded
-        
-
-
-

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,7 +31,7 @@ class TestConfig:
         Patch load_config in class Config
         The return value from load_config is changed to `{}`
         """
-        return mocker.patch("src.config.Config.load_config", return_value={})
+        return mocker.patch("src.config.Config._load_config", return_value={})
 
     def test_creation(self, setup, patch_config):
         assert Config() is not None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,7 +43,7 @@ class TestConfig:
         Config(), Config(), Config(), Config(), Config()
         patch_load_config.assert_called_once()
 
-    def test_save_config_correctly_saves_config(self, setup, patch_config):
+    def test_dump_config_correctly_saves_config(self, setup, patch_config):
         # Read config from file and modify values
         Config().set_bing_api_key("10random_bing_key01")
         Config().set_logs_dir("10random_logs_dir01")


### PR DESCRIPTION
The main goal of this pull request is to add tests to the Config class.

Additional changes:
* Created class constant _CONFIG_FILE to replace string literal "config.toml".
This is necessary for testing purposes and good practice in general.
* Created class constant _SAMPLE_CONFIG_FILE to replace string literal "sample.config.toml".
This is necessary for testing purposes and good practice in general.
* Renamed save_config to dump_config
To have the same function names as toml
* Added ".vscode/" to .gitignore
This is useful not to commit VS Code project settings

This pull request includes the commit from #221,  so I will close it. 
