### PR TITLE
Fix code writing error caused due to variable shadowing

### DIFF
--- a/src/agents/feature/feature.py
+++ b/src/agents/feature/feature.py
@@ -85,13 +85,13 @@ class Feature:
 
     def emulate_code_writing(self, code_set: list, project_name: str):
         for file in code_set:
-            file = file["file"]
+            filename = file["file"]
             code = file["code"]
 
             new_state = AgentState().new_state()
             new_state["internal_monologue"] = "Writing code..."
-            new_state["terminal_session"]["title"] = f"Editing {file}"
-            new_state["terminal_session"]["command"] = f"vim {file}"
+            new_state["terminal_session"]["title"] = f"Editing {filename}"
+            new_state["terminal_session"]["command"] = f"vim {filename}"
             new_state["terminal_session"]["output"] = code
             AgentState().add_to_current_state(project_name, new_state)
             time.sleep(1)


### PR DESCRIPTION
Fix code writing error caused due to variable shadowing, resulting in the following error: 

```
Exception in thread Thread-3 (<lambda>):
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/ayomawijethunga/git/devika/devika.py", line 90, in <lambda>
    thread = Thread(target=lambda: agent.subsequent_execute(message, project_name))
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ayomawijethunga/git/devika/src/agents/agent.py", line 216, in subsequent_execute
    code = self.feature.execute(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ayomawijethunga/git/devika/src/agents/feature/feature.py", line 115, in execute
    self.emulate_code_writing(valid_response, project_name)
  File "/Users/ayomawijethunga/git/devika/src/agents/feature/feature.py", line 89, in emulate_code_writing
    code = file["code"]
           ~~~~^^^^^^^^
TypeError: string indices must be integers, not 'str'
```