### PR TITLE
Disabled flex-shrink for plan checkboxes

### DIFF
--- a/ui/src/lib/components/MessageContainer.svelte
+++ b/ui/src/lib/components/MessageContainer.svelte
@@ -50,7 +50,7 @@
               {#if JSON.parse(message.message)}
                 {#each Object.entries(JSON.parse(message.message)) as [step, description]}
                   <div class="flex gap-2 items-center">
-                    <input type="checkbox" id="step-{step}" disabled />
+                    <input type="checkbox" id="step-{step}" class="flex-shrink-0" disabled />
                     <label for="step-{step}"><strong>Step {step}</strong>: {description}</label>
                   </div>
                 {/each}


### PR DESCRIPTION
Small fix to disable flex for checkbox in the step-by-step plan dialog. Currently the boxes are appearing squished ( as shown in the screenshot )

![2024-04-04 07_50_55-2024-04-04 07_26_12-Mozilla Firefox png - IrfanView](https://github.com/stitionai/devika/assets/19407404/6c4e9b64-cf03-4391-93b4-6d28f6140f0b)
