### PR TITLE
Update logger.py, Fix log warnings

### DIFF
--- a/src/logger.py
+++ b/src/logger.py
@@ -10,7 +10,7 @@ class Logger:
     def __init__(self, filename="devika_agent.log"):
         config = Config()
         logs_dir = config.get_logs_dir()
-        self.logger = LogInit(pathName=logs_dir + "/" + filename, console=True, colors=True)
+        self.logger = LogInit(pathName=logs_dir + "/" + filename, console=True, colors=True, encoding="utf-8")
 
     def read_log_file(self) -> str:
         with open(self.logger.pathName, "r") as file:


### PR DESCRIPTION
resolves the error that causes the warning
`Traceback (most recent call last):
File "C:\Users\Pc\anaconda3\envs\devika\lib\site-packages\fastlogging\fastlogging.py", line 401, in _logMessage
self.__writePending()
File "C:\Users\Pc\anaconda3\envs\devika\lib\site-packages\fastlogging\fastlogging.py", line 360, in __writePending
self.F.write(data)
File "C:\Users\Pc\anaconda3\envs\devika\lib\encodings\cp1252.py", line 19, in encode
return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f64c' in position 120: character maps to`
