### PR TITLE
Fix AttributeError by adding 'browser' attribute to Agent class

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -39,6 +39,7 @@ class Agent:
             raise ValueError("base_model is required")
 
         self.logger = Logger()
+        self.browser = browser 
 
         """
         Accumulate contextual keywords from chained prompts of all preparation agents


### PR DESCRIPTION
 This fix addresses an issue where the 'Agent' object was missing a 'browser' attribute, causing some trouble. By adding `self.browser = browser` to the `Agent` class
 
Which would solve the https://github.com/stitionai/devika/issues/331