### PR TITLE
Better response parsing

### DIFF
--- a/src/agents/action/action.py
+++ b/src/agents/action/action.py
@@ -25,11 +25,9 @@ class Action:
 
     def validate_response(self, response: str):
         response = response.strip().replace("```json", "```")
-        
-        if response.startswith("```") and response.endswith("```"):
-            response = response[3:-3].strip()
  
         try:
+            response = response.split("```")[1].split("```")[0]
             response = json.loads(response)
         except Exception as _:
             return False

--- a/src/agents/answer/answer.py
+++ b/src/agents/answer/answer.py
@@ -27,10 +27,8 @@ class Answer:
     def validate_response(self, response: str):
         response = response.strip().replace("```json", "```")
         
-        if response.startswith("```") and response.endswith("```"):
-            response = response[3:-3].strip()
- 
         try:
+            response = response.split("```")[1].split("```")[0]
             response = json.loads(response)
         except Exception as _:
             return False

--- a/src/agents/decision/decision.py
+++ b/src/agents/decision/decision.py
@@ -17,11 +17,9 @@ class Decision:
 
     def validate_response(self, response: str):
         response = response.strip().replace("```json", "```")
-        
-        if response.startswith("```") and response.endswith("```"):
-            response = response[3:-3].strip()
 
         try:
+            response = response.split("```")[1].split("```")[0]
             response = json.loads(response)
         except Exception as _:
             return False

--- a/src/agents/internal_monologue/internal_monologue.py
+++ b/src/agents/internal_monologue/internal_monologue.py
@@ -17,11 +17,9 @@ class InternalMonologue:
 
     def validate_response(self, response: str):
         response = response.strip().replace("```json", "```")
-        
-        if response.startswith("```") and response.endswith("```"):
-            response = response[3:-3].strip()
  
         try:
+            response = response.split("```")[1].split("```")[0]
             response = json.loads(response)
         except Exception as _:
             return False

--- a/src/agents/researcher/researcher.py
+++ b/src/agents/researcher/researcher.py
@@ -25,9 +25,8 @@ class Researcher:
     def validate_response(self, response: str) -> dict | bool:
         response = response.strip().replace("```json", "```")
 
-        if response.startswith("```") and response.endswith("```"):
-            response = response[3:-3].strip()
         try:
+            response = response.split("```")[1].split("```")[0]
             response = json.loads(response)
         except Exception as _:
             return False

--- a/src/agents/runner/runner.py
+++ b/src/agents/runner/runner.py
@@ -53,11 +53,9 @@ class Runner:
 
     def validate_response(self, response: str):
         response = response.strip().replace("```json", "```")
-        
-        if response.startswith("```") and response.endswith("```"):
-            response = response[3:-3].strip()
  
         try:
+            response = response.split("```")[1].split("```")[0]
             response = json.loads(response)
         except Exception as _:
             return False
@@ -69,13 +67,11 @@ class Runner:
         
     def validate_rerunner_response(self, response: str):
         response = response.strip().replace("```json", "```")
-        
-        if response.startswith("```") and response.endswith("```"):
-            response = response[3:-3].strip()
  
         print(response)
  
         try:
+            response = response.split("```")[1].split("```")[0]
             response = json.loads(response)
         except Exception as _:
             return False


### PR DESCRIPTION
1. Currently, in response parsing, it expects from the LLM to send the message with proper JSON format without any other content. This can sometimes lead to many response failures and multiple API calls to the LLM.

![image](https://github.com/stitionai/devika/assets/72060359/da1977c5-5625-44bf-aa16-500c9d07ae03)
Some response with this structure would fail the parsing

2. In this PR, have modified that logic on how the response is parsed