### PR TITLE
Improvement for the issue :  Not working with LLM #396 

### DIFF
--- a/src/agents/researcher/prompt.jinja2
+++ b/src/agents/researcher/prompt.jinja2
@@ -18,6 +18,7 @@ Only respond in the following JSON format:
     "ask_user": "<ASK INPUT FROM USER>"
 }
 ```
+Strictly do not add any other extra sections of information in your response apart from the JSON format mentioned above.
 
 Keywords for Search Query: {{ contextual_keywords }}
 


### PR DESCRIPTION
Explicitly informing the model not include uneccessary reponses sections in its output. This is done because some models like llama2 provide sections such as "Explanation:" or "Justification:" after the JSON response.
This is not a surefire fix though. The model (llama2) will still includes explanation and justification sections at times despite this explicit instruction in the prompt