### PR TITLE
Update prompt.jinja2 with an example for more consistent format reply (https://github.com/stitionai/devika/issues/429)

### DIFF
--- a/src/agents/planner/prompt.jinja2
+++ b/src/agents/planner/prompt.jinja2
@@ -22,9 +22,23 @@ Plan:
 Summary: <Briefly summarize the plan, highlighting any key considerations, dependencies, or potential challenges.>
 ```
 
+For example, consider a project about user registration system, then this would be the exact output(not even change of lowercase and uppercase of Project Name or Plan or Summary, etc).
+```
+Project Name: User Registration System
+
+Your Reply to the Human Prompter: I've broken down the steps to build a basic user registration page with a database that stores user data. Let's get started!
+
+Current Focus: Establish the database to store user information.
+
+Plan:
+- [ ] Step 1: Create a database using MySQL or PostgreSQL.
+- [ ] Step 2: Design a table with columns for user information, such as name, email, password, and other relevant fields.
+
+Summary: This plan focuses on setting up the database to store user data securely and efficiently. By following these steps, you'll have a solid foundation for your user registration system.
+```
 Each step should be a clear, concise description of a specific task or action required. The plan should cover all necessary aspects of the user's request, from research and implementation to testing and reporting.
 
-Write the plan with knowing that you have access to the browser and search engine to accomplish the task.
+Write the plan knowing that you have access to the browser and search engine to accomplish the task.
 
 After listing the steps, provide a brief summary of the plan, highlighting any key considerations, dependencies, or potential challenges.
 


### PR DESCRIPTION
Changed the prompt by giving an example for more consistent replies as sometimes the plan doesn't show up. Issue: https://github.com/stitionai/devika/issues/429

---
name: Addition of example in prompt of Planner for more consistent replies (https://github.com/stitionai/devika/issues/429)
---

### Description

*[ ] Added an example for Planner to give more consistent replies not leaving blank in Plan when planning for a task.


Explain what existing problem does the pull request solve?
After adding an example, more consistent format of replies for planner comes, resulting in a non-empty plan (https://github.com/stitionai/devika/issues/429)