### PR TITLE
"Improve error handling for Ctrl+C/Exit/Error in devika.py and Bug fixes

### DIFF
--- a/devika.py
+++ b/devika.py
@@ -15,6 +15,7 @@ import os
 import logging
 from threading import Thread
 import tiktoken
+from contextlib import ExitStack
 
 from src.apis.project import project_bp
 from src.config import Config
@@ -197,3 +198,16 @@ def get_settings():
 if __name__ == "__main__":
     logger.info("Devika is up and running!")
     socketio.run(app, debug=False, port=1337, host="0.0.0.0")
+
+def handle_error(sig, frame):
+  """
+  Handles errors and Ctrl+C interruption by setting agent inactive and completed.
+  """
+  print("Error or Ctrl+C detected!")
+  AgentState.set_agent_active(project_name, False)
+  AgentState.set_agent_completed(project_name, True)
+  sys.exit(1)  # Exit with non-zero code to indicate error
+
+# Use ExitStack for cleaner management of signal handler
+with ExitStack() as stack:
+  stack.push(signal.signal(signal.SIGINT, handle_error))

--- a/src/agents/runner/runner.py
+++ b/src/agents/runner/runner.py
@@ -52,14 +52,17 @@ class Runner:
         )
 
     def validate_response(self, response: str):
-        response = response.strip().replace("```json", "```")
-        
-        if response.startswith("```") and response.endswith("```"):
-            response = response[3:-3].strip()
- 
+        #Find the start and end of the JSON in the response
+        start = response.index('{')
+        end = response.rindex('}') + 1
+
+        #Extract the JSON part of the response
+        json_part = response[start:end]
+
         try:
-            response = json.loads(response)
-        except Exception as _:
+            #Load the JSON to a Python dict
+            response = json.loads(json_part)
+        except json.JSONDecodeError:
             return False
 
         if "commands" not in response:
@@ -68,19 +71,18 @@ class Runner:
             return response["commands"]
         
     def validate_rerunner_response(self, response: str):
-        response = response.strip().replace("```json", "```")
-        
-        if response.startswith("```") and response.endswith("```"):
-            response = response[3:-3].strip()
- 
-        print(response)
- 
+        #Find the start and end of the JSON in the response
+        start = response.index('{')
+        end = response.rindex('}') + 1
+
+        #Extract the JSON part of the response
+        json_part = response[start:end]
+
         try:
-            response = json.loads(response)
-        except Exception as _:
+            #Load the JSON to a Python dict
+            response = json.loads(json_part)
+        except json.JSONDecodeError:
             return False
-        
-        print(response)
 
         if "action" not in response and "response" not in response:
             return False
@@ -102,13 +104,15 @@ class Runner:
             command_set = command.split(" ")
             command_failed = False
             
-            process = subprocess.run(
+            process = subprocess.Popen(
                 command_set,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                cwd=project_path
+                cwd=project_path,
+                universal_newlines=True  # Capture output as strings (optional)
+
             )
-            command_output = process.stdout.decode('utf-8')
+            command_output = process.communicate()
             command_failed = process.returncode != 0
             
             new_state = AgentState().new_state()
@@ -162,13 +166,15 @@ class Runner:
                     command_set = command.split(" ")
                     command_failed = False
                     
-                    process = subprocess.run(
+                    process = subprocess.Popen(
                         command_set,
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
-                        cwd=project_path
+                        cwd=project_path,
+                        universal_newlines=True  # Capture output as strings (optional)
+
                     )
-                    command_output = process.stdout.decode('utf-8')
+                    command_output = process.communicate()
                     command_failed = process.returncode != 0
                     
                     new_state = AgentState().new_state()


### PR DESCRIPTION
### Description

Changes in devika.py

A new import statement has been added: from contextlib import ExitStack. This suggests that the code is using the ExitStack context manager to manage resources, such as signal handlers. A new function handle_error has been added. This function appears to handle errors and Ctrl+C interruptions by setting an agent's state to inactive and completed. It also exits the program with a non-zero code to indicate an error. The handle_error function is registered as a signal handler for SIGINT (Ctrl+C) using the signal module and ExitStack.

Changes in runner.py

The validate_response and validate_rerunner_response methods have been modified to extract JSON data from the response string. The old implementation used strip() and replace() to remove unwanted characters, whereas the new implementation uses index() and rindex() to find the start and end of the JSON data. The JSON data is now extracted using slicing (response[start:end]) and loaded into a Python dictionary using json.loads().

The subprocess module is now used with Popen instead of run. This change allows for more flexibility in handling the subprocess output. The universal_newlines=True parameter has been added to the Popen constructor. This allows the output to be captured as strings instead of bytes. The communicate() method is now used to capture the output of the subprocess, instead of stdout.decode('utf-8'). Impact of changes

The changes in devika.py appear to improve the handling of errors and Ctrl+C interruptions, making the program more robust.

The changes in runner.py seem to improve the parsing of JSON data from responses and the handling of subprocess output.

The use of Popen instead of run allows for more flexibility in handling the output, and the universal_newlines=True parameter makes it easier to work with string output.

### Issues Fixed

 **Allows the user to view the Error in UI Terminal before devika starts prompting for fixes.**

**Updates Agent State to inactive after error or before exit (Bug: Espically when Terminal runs a webapp, there is no way to terminate the process, terminating devika causes the agent to freeze in "active" state.**

 **No more Invalid Json from Llama 3 due to text outside Json Blocks. (ex.  Here is the formatted Json Block { ... })**