### PR TITLE
Netlify Deploy Fix

### DIFF
--- a/src/services/netlify.py
+++ b/src/services/netlify.py
@@ -12,7 +12,7 @@ class Netlify:
     def deploy(self, project_name: str):
         project_path = ProjectManager().get_project_path(project_name)
         
-        site = self.netlify.site.create_site()
+        site = self.netlify.sites.create_site()
         
         print("===" * 10)
         print(site)


### PR DESCRIPTION
Fixed Netlify Deploy Error.
Line: 15 it should be sites not site.
AttributeError: 'NetlifyPy' object has no attribute 'site'. Did you mean: 'sites'?


Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide. -->

### Description

<!-- Describe the changes in this PR. -->

for e.g.
* [ ] Netlify Deploy Error

When it tried to deploy code to netlify it was giving error as netlify on create site from attribute sites.

