### PR TITLE
Fix: Fix the io.UnsupportedOperation: not readable

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -14,8 +14,9 @@ class Config:
     def _load_config(self):
         # If the config file doesn't exist, copy from the sample
         if not os.path.exists("config.toml"):
-            with open("sample.config.toml", "r") as f_in, open("config.toml", "w") as f_out:
+            with open("sample.config.toml", "r") as f_in, open("config.toml", "w+") as f_out:
                 f_out.write(f_in.read())
+                f_out.seek(0)
                 self.config = toml.load(f_out)
         else:
             # check if all the keys are present in the config file


### PR DESCRIPTION
### Description

This pull request fixes a critical bug where the application was unable to read the configuration file (config.toml) immediately after creating it from a template (sample.config.toml). This issue led to an io.UnsupportedOperation: not readable error.

* [ ] Bug io.UnsupportedOperation: not readable

**Root Cause**: The file pointer was at the end of the file after writing, making the subsequent read operation fail because there was no data left to read at the pointer's location.

**Resolution**: The code has been adjusted to open the file in w+ mode instead of w, which allows for both writing and reading. Additionally, the file pointer is reset to the start of the file before attempting to read, ensuring that the freshly written data can be loaded into the application's configuration.

### Test plan

**Environment Setup:** 
Ensure that no config.toml exists and only sample.config.toml is present.

**Execution:** 
Run the application initialization sequence that triggers the config loading.

**Verification:**
Check that config.toml is created from sample.config.toml.
Verify that the application starts without throwing the io.UnsupportedOperation: not readable error.
Confirm that the settings in config.toml are correctly loaded into the application by printing/logging the configuration after initialization.

**Expected Result:** The application should correctly create and read config.toml, loading the configuration as expected without errors.

Before:
<img width="1004" alt="image" src="https://github.com/stitionai/devika/assets/46117442/bb67787a-baea-4e6e-b785-cb953af5d467">
After:
<img width="1001" alt="image" src="https://github.com/stitionai/devika/assets/46117442/1db2be99-0a96-47a6-8ccb-840d3d1a5ede">