### PR TITLE
Docs: corrected typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Version's requirements
 
 - Install uv - Python Package manager [download](https://github.com/astral-sh/uv)
 - Install bun - JavaScript runtime [download](https://bun.sh/docs/installation)
-- For ollama [ollama setup guide](docs/Installation/ollama.md) (optinal: if you don't want to use the local models then you can skip this step)
-- For API models, configure the API keys via setting page in UI.
+- For ollama [ollama setup guide](docs/Installation/ollama.md) (optional: if you don't want to use the local models then you can skip this step)
+- For API models, configure the API keys via setting page in UI, after the installation.
 
 
 ### Installation


### PR DESCRIPTION
There was a typo in the word "optional" which I corrected, and made the next line more comprehensive for anyone installing. 
It now mentions that the UI will be available after following the next installation steps, as obvious as that may seem.
