### PR TITLE
Fix: list index out of range error

### DIFF
--- a/src/agents/coder/coder.py
+++ b/src/agents/coder/coder.py
@@ -52,7 +52,7 @@ class Coder:
             if line.startswith("File: "):
                 if current_file and current_code:
                     result.append({"file": current_file, "code": "\n".join(current_code)})
-                current_file = line.split("`")[1].strip()
+                current_file = line.split(":")[1].strip()
                 current_code = []
                 code_block = False
             elif line.startswith("```"):


### PR DESCRIPTION
### Description

Fix for https://github.com/stitionai/devika/issues/546. It seems that the line needed to be split on ":" instead of "`", because there will always be a colon when the line starts with "File: ".