### PR TITLE
Fix: Strip backquote from generated filenames

### DIFF
--- a/src/agents/coder/coder.py
+++ b/src/agents/coder/coder.py
@@ -52,7 +52,7 @@ class Coder:
             if line.startswith("File: "):
                 if current_file and current_code:
                     result.append({"file": current_file, "code": "\n".join(current_code)})
-                current_file = line.split(":")[1].strip()
+                current_file = line.split(":")[1].replace("`", "").strip()
                 current_code = []
                 code_block = False
             elif line.startswith("```"):


### PR DESCRIPTION
### Description

Fixes https://github.com/stitionai/devika/issues/566

### Test plan (required)

Previously, the generated filenames were surrounded by backquotes. After running with this change, the generated filenames no longer have backquotes.


### Closing issues (optional)

Fixes #566 