### PR TITLE
Update requirements.txt with curl_cffi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ duckduckgo-search
 orjson
 gevent
 gevent-websocket
+curl_cffi


### PR DESCRIPTION

**Exception in thread Thread-7 (<lambda>):**

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/home/ubuntu/devika/devika.py", line 85, in <lambda>
    thread = Thread(target=lambda: agent.execute(message, project_name))
  File "/home/ubuntu/devika/src/agents/agent.py", line 344, in execute
    search_results = self.search_queries(queries, project_name)
  File "/home/ubuntu/devika/src/agents/agent.py", line 89, in search_queries
    web_search = DuckDuckGoSearch()
  File "/home/ubuntu/devika/src/browser/search.py", line 94, in __init__
    from curl_cffi import requests as curl_requests
ModuleNotFoundError: No module named 'curl_cffi'
```

**Description:**

This pull request addresses an issue where the `curl_cffi` module is not found, causing a `ModuleNotFoundError` when attempting to initialize a `DuckDuckGoSearch` instance. The error occurs in the `search.py` file during the import of `curl_cffi`.

- [x] Bug: ModuleNotFoundError due to missing `curl_cffi` module
- [ ] Additional bugs or features to be addressed in future PRs

**Problem Solved:**

The pull request solves the issue by ensuring that the `curl_cffi` module is correctly installed and available for use within the project. This is crucial for the proper functioning of the web search functionality implemented in `search.py`.

**Test Plan (required):**

1. **Installation Check:** Verify that `curl_cffi` is installed in the project environment.
2. **Functionality Test:** Run the `devika.py` script and ensure that the web search functionality works without raising a `ModuleNotFoundError`.
3. **Integration Test:** Ensure that other functionalities dependent on the web search are also functioning correctly.

**Closing Issues (optional):**