### PR TITLE
Fix: Issue #599, DuckDuckGo Search Module Not Found

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ duckduckgo-search
 orjson
 gevent
 gevent-websocket
+curl_cffi


### PR DESCRIPTION
### Description
It is a minor fix for a bug that mentioned in [#599](https://github.com/stitionai/devika/issues/599),
A module(`curl_cffi`) was missing from requirements.txt which is required to make the DuckDuckGo Search work , due to which agent would randomly stop while working on a problem that required internet search (when search engine was set to DuckDuckGo)

### Changes -> 
* [x] Added missing module to requirements.txt

Explain what existing problem does the pull request solve?
- Fixing the issue of agent (`with DuckDuckGo as search engine`) stopping randomly when it starts browsing the web without the `curl_cffi` module.


### Test plan (required)
- Running Agent with DuckDuckGo as Search Engine works after this change of `requirements.txt`
![image](https://github.com/stitionai/devika/assets/127482713/7abd7792-7700-438b-b711-ab49955da69a)


Fixes #599 