### PR TITLE
[Security Issue] Apply secure_filename to snapshot_path for security hardening

### DIFF
--- a/devika.py
+++ b/devika.py
@@ -9,6 +9,7 @@ init_devika()
 
 
 from flask import Flask, request, jsonify, send_file
+from werkzeug.utils import secure_filename
 from flask_cors import CORS
 from src.socket_instance import socketio, emit_agent
 import os
@@ -123,7 +124,7 @@ def get_agent_state():
 @app.route("/api/get-browser-snapshot", methods=["GET"])
 @route_logger(logger)
 def browser_snapshot():
-    snapshot_path = request.args.get("snapshot_path")
+    snapshot_path = secure_filename(request.args.get("snapshot_path"))
     return send_file(snapshot_path, as_attachment=True)
 
 
@@ -207,5 +208,3 @@ def status():
 if __name__ == "__main__":
     logger.info("Devika is up and running!")
     socketio.run(app, debug=False, port=1337, host="0.0.0.0")
-
-123

--- a/devika.py
+++ b/devika.py
@@ -207,3 +207,5 @@ def status():
 if __name__ == "__main__":
     logger.info("Devika is up and running!")
     socketio.run(app, debug=False, port=1337, host="0.0.0.0")
+
+123


### PR DESCRIPTION
### Description

* [x] **Security fix** – Resolved a **path injection vulnerability** in the `snapshot_path` parameter.

This change uses `secure_filename` from `werkzeug.utils` to sanitize the `snapshot_path` value obtained from user input, preventing malicious path traversal or unauthorized file access.

### Problem

Previously, the `snapshot_path` parameter was used without validation. An attacker could exploit this by passing values like `../../etc/passwd`, potentially gaining access to sensitive files on the server. This posed a serious **path injection** security risk.

### Code Change

```python
from werkzeug.utils import secure_filename

snapshot_path = secure_filename(request.args.get("snapshot_path"))
```

The `secure_filename` function ensures the input is converted to a safe, valid filename, effectively blocking directory traversal attempts.

### Test Plan

- Attempted path injection using `snapshot_path=../../etc/passwd`
- **Before fix**: Able to access unintended paths
- **After fix**: Filename is sanitized (e.g., becomes `etc_passwd`), preventing unauthorized access
